### PR TITLE
Check if liveupdate project was built with excluded files

### DIFF
--- a/atlas_loader/mount_loader.lua
+++ b/atlas_loader/mount_loader.lua
@@ -291,7 +291,8 @@ function M.load(info)
     if M.use_html_loader and html_loader then
         html_loader.show()
     end
-    if not liveupdate or not liveupdate.is_built_with_excluded_files() then
+    if not liveupdate
+        or (type(liveupdate.is_built_with_excluded_files) == "function" and not liveupdate.is_built_with_excluded_files()) then
         mount_loaded(data)
     else
         ---@type atlas_mount[]

--- a/atlas_loader/mount_loader.lua
+++ b/atlas_loader/mount_loader.lua
@@ -291,7 +291,7 @@ function M.load(info)
     if M.use_html_loader and html_loader then
         html_loader.show()
     end
-    if not liveupdate then
+    if not liveupdate or not liveupdate.is_built_with_excluded_files() then
         mount_loaded(data)
     else
         ---@type atlas_mount[]

--- a/game.project
+++ b/game.project
@@ -13,7 +13,7 @@ input_method = HiddenInputField
 
 [project]
 title = AtlasLoader
-version = 1.1.4
+version = 1.1.5
 dependencies#0 = https://github.com/andsve/dirtylarry/archive/refs/heads/master.zip
 
 [library]


### PR DESCRIPTION
Require Defold 1.9.7-beta version.
Fix issue, when `liveupdate` is not nil, but project was built without excluded files (e.g. from editor).